### PR TITLE
Had to Access-Control-Allow-Origin to stateMachineXgiHandler, but not…

### DIFF
--- a/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
+++ b/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
@@ -671,6 +671,7 @@ void GatewaySupervisor::stateMachineXgiHandler(xgi::Input* in, xgi::Output* out)
 	if(VERBOSE_MUTEX)
 		__COUT__ << "Have FSM access" << __E__;
 
+	out->getHTTPResponseHeader().addHeader("Access-Control-Allow-Origin", "*");  // to avoid block by blocked by CORS policy of browser
 	cgicc::Cgicc cgiIn(in);
 
 	std::string command     = CgiDataUtilities::getData(cgiIn, "StateMachine");


### PR DESCRIPTION
Adding this line, which is already present in request, stops chrome for complaining when I send a command