### PR TITLE
Rrivera/mongo db load aliases optimization

### DIFF
--- a/otsdaq/ConfigurationInterface/ConfigurationManager.h
+++ b/otsdaq/ConfigurationInterface/ConfigurationManager.h
@@ -43,11 +43,11 @@ class ConfigurationManager
 	static const std::string ARTDAQ_TOP_TABLE_NAME;
 	static const std::string DESKTOP_ICON_TABLE_NAME;
 
-	static const std::string ACTIVE_GROUP_NAME_CONTEXT;
-	static const std::string ACTIVE_GROUP_NAME_BACKBONE;
-	static const std::string ACTIVE_GROUP_NAME_ITERATE;
-	static const std::string ACTIVE_GROUP_NAME_CONFIGURATION;
-	static const std::string ACTIVE_GROUP_NAME_UNKNOWN;
+	static const std::string GROUP_TYPE_NAME_CONTEXT;
+	static const std::string GROUP_TYPE_NAME_BACKBONE;
+	static const std::string GROUP_TYPE_NAME_ITERATE;
+	static const std::string GROUP_TYPE_NAME_CONFIGURATION;
+	static const std::string GROUP_TYPE_NAME_UNKNOWN;
 
 	static const std::string LAST_TABLE_GROUP_SAVE_PATH;
 	static const std::string LAST_ACTIVATED_CONFIG_GROUP_FILE;
@@ -66,9 +66,12 @@ class ConfigurationManager
 	std::set<std::string>              configurationMemberNames_;  // list of 'active' configuration members
 
 	static const std::string 			CONTEXT_SUBSYSTEM_OPTIONAL_TABLE;
+	static const std::string 			UNKNOWN_INFO;
+	static const std::string 			UNKNOWN_TIME;
 
 	enum class GroupType
 	{
+		UNKNOWN_TYPE,
 		CONTEXT_TYPE,
 		BACKBONE_TYPE,
 		ITERATE_TYPE,
@@ -212,6 +215,7 @@ const T* retPtr = dynamic_cast<const T*>(srcPtr); if(retPtr == nullptr) { __SS__
 																	std::string*		 					accumulatedWarnings,			
 																	std::mutex* 							threadMutex,	
 																	std::shared_ptr<std::atomic<bool>> 		threadDone);
+	
 
   protected: 
 	std::string 										mfSubject_;

--- a/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
@@ -373,10 +373,10 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 						{
 							__GEN_COUT_WARN__ << "Error occurred loading latest group info into cache for '"
 											<< groupInfo.first << "(" << groupInfo.second.getLatestKey() << ")'..." << __E__;
-							groupInfo.second.latestKeyGroupComment_      = "UNKNOWN";
-							groupInfo.second.latestKeyGroupAuthor_       = "UNKNOWN";
-							groupInfo.second.latestKeyGroupCreationTime_ = "0";
-							groupInfo.second.latestKeyGroupTypeString_   = "UNKNOWN";
+							groupInfo.second.latestKeyGroupComment_      = ConfigurationManager::UNKNOWN_INFO;
+							groupInfo.second.latestKeyGroupAuthor_       = ConfigurationManager::UNKNOWN_INFO;
+							groupInfo.second.latestKeyGroupCreationTime_ = ConfigurationManager::UNKNOWN_TIME;
+							groupInfo.second.latestKeyGroupTypeString_   = ConfigurationManager::GROUP_TYPE_NAME_UNKNOWN;
 						}
 					}  // end group info loop
 				else //multi-threading
@@ -414,13 +414,15 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 						*(threadDone[foundThreadIndex]) = false;
 
 						std::thread([](
-							ConfigurationManagerRW* 				cfgMgr, 
-							std::string 							groupName, 
+							ConfigurationManagerRW* 				theCfgMgr, 
+							std::string 							theGroupName, 
+							ots::TableGroupKey						theGroupKey,
 							ots::GroupInfo*                       	theGroupInfo,
 		               		std::shared_ptr<std::atomic<bool>> 		theThreadDone) { 
-						ConfigurationManagerRW::loadTableGroupThread(cfgMgr, groupName, theGroupInfo, theThreadDone); },
+						ConfigurationManagerRW::loadTableGroupThread(theCfgMgr, theGroupName, theGroupKey, theGroupInfo, theThreadDone); },
 							this,
 							groupInfo.first,
+							groupInfo.second.getLatestKey(),
 							&(groupInfo.second),
 							threadDone[foundThreadIndex])
 		    			.detach();
@@ -479,12 +481,13 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 // loadTableGroupThread()
 void ConfigurationManagerRW::loadTableGroupThread(ConfigurationManagerRW* 				cfgMgr, 
 													std::string 						groupName, 
+													ots::TableGroupKey					groupKey,
 													ots::GroupInfo*  					groupInfo, 
 													std::shared_ptr<std::atomic<bool>> 	threadDone)
 try
 {
 	cfgMgr->loadTableGroup(groupName/*groupName*/,
-		groupInfo->getLatestKey(),
+		groupKey, //groupInfo->getLatestKey(),
 		false /*doActivate*/,
 		&groupInfo->latestKeyMemberMap_ /*groupMembers*/,
 		0 /*progressBar*/,
@@ -501,10 +504,10 @@ catch(...)
 {
 	__COUT_WARN__ << "Error occurred loading latest group info into cache for '"
 		<< groupName << "(" << groupInfo->getLatestKey() << ")'..." << __E__;
-	groupInfo->latestKeyGroupComment_      = "UNKNOWN";
-	groupInfo->latestKeyGroupAuthor_       = "UNKNOWN";
-	groupInfo->latestKeyGroupCreationTime_ = "0";
-	groupInfo->latestKeyGroupTypeString_   = "UNKNOWN";
+	groupInfo->latestKeyGroupComment_      = ConfigurationManager::UNKNOWN_INFO;
+	groupInfo->latestKeyGroupAuthor_       = ConfigurationManager::UNKNOWN_INFO;
+	groupInfo->latestKeyGroupCreationTime_ = ConfigurationManager::UNKNOWN_TIME;
+	groupInfo->latestKeyGroupTypeString_   = ConfigurationManager::GROUP_TYPE_NAME_UNKNOWN;
 	*(threadDone) = true;
 } // end loadTableGroupThread catch
 
@@ -1869,6 +1872,92 @@ void GroupEditStruct::saveChanges(const std::string& groupNameToSave,
 //Used for debugging Configuration calls during development
 void ConfigurationManagerRW::testXDAQContext()
 {
+	if(1) return; //if 0 to debug
+	__GEN_COUTV__(runTimeSeconds());
+
+	std::string accumulatedWarningsStr;
+	std::string* accumulatedWarnings = &accumulatedWarningsStr;
+
+	// get Group Info too!
+	try
+	{
+		// build allGroupInfo_ for the ConfigurationManagerRW
+
+		std::set<std::string /*name*/> tableGroups = theInterface_->getAllTableGroupNames();
+		__GEN_COUT__ << "Number of Groups: " << tableGroups.size() << __E__;
+
+		__GEN_COUTV__(runTimeSeconds());
+		TableGroupKey key;
+		std::string   name;
+		for(const auto& fullName : tableGroups)
+		{
+			TableGroupKey::getGroupNameAndKey(fullName, name, key);
+			cacheGroupKey(name, key);
+		}
+		__GEN_COUTV__(runTimeSeconds());
+		// for each group get member map & comment, author, time, and type for latest key
+		for(auto& groupInfo : allGroupInfo_)
+		{
+			try
+			{
+				loadTableGroup(groupInfo.first /*groupName*/,
+				               groupInfo.second.getLatestKey(),
+				               false /*doActivate*/,
+				               &groupInfo.second.latestKeyMemberMap_ /*groupMembers*/,
+				               0 /*progressBar*/,
+				               0 /*accumulateErrors*/,
+				               &groupInfo.second.latestKeyGroupComment_,
+				               &groupInfo.second.latestKeyGroupAuthor_,
+				               &groupInfo.second.latestKeyGroupCreationTime_,
+				               true /*doNotLoadMember*/,
+				               &groupInfo.second.latestKeyGroupTypeString_);
+			}
+			catch(const std::runtime_error& e)
+			{
+				__GEN_COUT_WARN__ << "Error occurred loading latest group info into cache for '"
+								 << groupInfo.first
+				                  << "(" << groupInfo.second.getLatestKey() << ")': \n" << e.what() << __E__;
+
+				groupInfo.second.latestKeyGroupComment_      = ConfigurationManager::UNKNOWN_INFO;
+				groupInfo.second.latestKeyGroupAuthor_       = ConfigurationManager::UNKNOWN_INFO;
+				groupInfo.second.latestKeyGroupCreationTime_ = ConfigurationManager::UNKNOWN_TIME;
+				groupInfo.second.latestKeyGroupTypeString_   = ConfigurationManager::GROUP_TYPE_NAME_UNKNOWN;
+			}
+			catch(...)
+			{
+				__GEN_COUT_WARN__ << "Error occurred loading latest group info into cache for '"
+								 << groupInfo.first
+				                  << "(" << groupInfo.second.getLatestKey() << ")'..." << __E__;
+				groupInfo.second.latestKeyGroupComment_      = ConfigurationManager::UNKNOWN_INFO;
+				groupInfo.second.latestKeyGroupAuthor_       = ConfigurationManager::UNKNOWN_INFO;
+				groupInfo.second.latestKeyGroupCreationTime_ = ConfigurationManager::UNKNOWN_TIME;
+				groupInfo.second.latestKeyGroupTypeString_   = ConfigurationManager::GROUP_TYPE_NAME_UNKNOWN;
+			}
+		}  // end group info loop
+		__GEN_COUTV__(runTimeSeconds());
+	}      // end get group info
+	catch(const std::runtime_error& e)
+	{
+		__SS__ << "A fatal error occurred reading the info for all table groups. Error: " << e.what() << __E__;
+		__GEN_COUT_ERR__ << "\n" << ss.str();
+		if(accumulatedWarnings)
+			*accumulatedWarnings += ss.str();
+		else
+			throw;
+	}
+	catch(...)
+	{
+		__SS__ << "An unknown fatal error occurred reading the info for all table groups." << __E__;
+		__GEN_COUT_ERR__ << "\n" << ss.str();
+		if(accumulatedWarnings)
+			*accumulatedWarnings += ss.str();
+		else
+			throw;
+	}
+	__GEN_COUT__ << "Group Info end runtime=" << runTimeSeconds() << __E__;
+	
+
+	return;
 	try
 	{
 		__GEN_COUT__ << "Loading table..." << __E__;

--- a/otsdaq/ConfigurationInterface/ConfigurationManagerRW.h
+++ b/otsdaq/ConfigurationInterface/ConfigurationManagerRW.h
@@ -10,8 +10,7 @@ struct TableInfo
 	TableInfo()
 	    :  // constructor
 	    tablePtr_(0)
-	{
-	}
+	{}
 
 	std::set<TableVersion> versions_;
 	TableBase*             tablePtr_;
@@ -19,6 +18,14 @@ struct TableInfo
 
 struct GroupInfo
 {
+	GroupInfo()
+		: //constructor
+		latestKeyGroupAuthor_		(ConfigurationManager::UNKNOWN_INFO),
+		latestKeyGroupComment_		(ConfigurationManager::UNKNOWN_INFO),
+		latestKeyGroupCreationTime_	(ConfigurationManager::UNKNOWN_TIME),
+		latestKeyGroupTypeString_	(ConfigurationManager::GROUP_TYPE_NAME_UNKNOWN)
+	{}
+
 	std::set<TableGroupKey> keys_;
 	std::string             latestKeyGroupAuthor_, latestKeyGroupComment_, latestKeyGroupCreationTime_, latestKeyGroupTypeString_;
 	std::map<std::string /*name*/, TableVersion /*version*/> latestKeyMemberMap_;
@@ -107,8 +114,12 @@ class ConfigurationManagerRW : public ConfigurationManager
 
 	void 										testXDAQContext					(void);  // for debugging
 
-  private:
-	static void 								loadTableGroupThread			(ConfigurationManagerRW* cfgMgr, std::string groupName, ots::GroupInfo*  theGroupInfo, std::shared_ptr<std::atomic<bool>> 		theThreadDone);
+  public:
+	static void 								loadTableGroupThread			(ConfigurationManagerRW* 			cfgMgr,
+																				std::string							groupName, 
+																				ots::TableGroupKey					groupKey,
+																				ots::GroupInfo*  					theGroupInfo, 
+																				std::shared_ptr<std::atomic<bool>> 	theThreadDone);
 	static void 								compareTableGroupThread			(ConfigurationManagerRW* 			cfgMgr, 
 																				std::string 						groupName, 
 																				ots::TableGroupKey 					groupKeyToCompare, 
@@ -118,7 +129,7 @@ class ConfigurationManagerRW : public ConfigurationManager
 																				ots::TableGroupKey* 				theIdenticalKey,			
 																				std::mutex* 						theThreadMutex,	
 																				std::shared_ptr<std::atomic<bool>> 	theThreadDone);
-
+  private:
 
 	//==============================================================================
 	// group cache handling

--- a/otsdaq/CoreSupervisors/ConfigurationSupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/ConfigurationSupervisorBase.cc
@@ -878,8 +878,8 @@ try
 	//		save, activate, and modify alias
 	// just to match syntax in ConfiguratGUI
 	//	tmpCfgMgr.activateTableGroup(
-	//			tmpCfgMgr.getActiveGroupName(ConfigurationManager::ACTIVE_GROUP_NAME_CONTEXT),
-	//			tmpCfgMgr.getActiveGroupKey(ConfigurationManager::ACTIVE_GROUP_NAME_CONTEXT)
+	//			tmpCfgMgr.getActiveGroupName(ConfigurationManager::GROUP_TYPE_NAME_CONTEXT),
+	//			tmpCfgMgr.getActiveGroupKey(ConfigurationManager::GROUP_TYPE_NAME_CONTEXT)
 	//			);
 
 	cfgMgr->restoreActiveTableGroups(

--- a/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
+++ b/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
@@ -1629,11 +1629,11 @@ try
 			true /*doNotLoadMember */,
 			&groupTypeString
 			);
-		if(groupTypeString != ConfigurationManager::ACTIVE_GROUP_NAME_CONFIGURATION)
+		if(groupTypeString != ConfigurationManager::GROUP_TYPE_NAME_CONFIGURATION)
 		{
 			__SS__ << "Illegal attempted configuration group type. The table group '" <<
 				theConfigurationTableGroup_.first << "(" << theConfigurationTableGroup_.second << ")' is of type " <<
-				groupTypeString << ". It must be " << ConfigurationManager::ACTIVE_GROUP_NAME_CONFIGURATION << "." << __E__;
+				groupTypeString << ". It must be " << ConfigurationManager::GROUP_TYPE_NAME_CONFIGURATION << "." << __E__;
 			__SS_THROW__;
 		}
 

--- a/otsdaq/SupervisorInfo/SupervisorInfo.cc
+++ b/otsdaq/SupervisorInfo/SupervisorInfo.cc
@@ -2,7 +2,7 @@
 
 using namespace ots;
 
-const std::string SupervisorInfo::APP_STATUS_UNKNOWN       = "Unknown";
+const std::string SupervisorInfo::APP_STATUS_UNKNOWN       = "UNKNOWN";
 const std::string SupervisorInfo::APP_STATUS_NOT_MONITORED = "Not Monitored";
 
 //=====================================================================================

--- a/otsdaq/WorkLoopManager/WorkLoopManager.cc
+++ b/otsdaq/WorkLoopManager/WorkLoopManager.cc
@@ -161,7 +161,7 @@ bool WorkLoopManager::getRequestResult(cgicc::Cgicc& cgi, HttpXmlDocument& xmlDo
 		reportStream << "Can't find request " << requestNumber << " within the currently active " << workLoops_.size() << " requests!";
 		__COUT__ << "WARNING: " << reportStream.str() << std::endl;
 		xmlDocument.addTextElementToData("RequestStatus", "WARNING");
-		xmlDocument.addTextElementToData("RequestName", "Unknown");
+		xmlDocument.addTextElementToData("RequestName", "UNKNOWN");
 		xmlDocument.addTextElementToData("RequestNumber", requestNumberString);
 		xmlDocument.addTextElementToData("ErrorReport", reportStream.str());
 		return false;

--- a/tools/otsdaq_fix_new_table_fields_tool.cc
+++ b/tools/otsdaq_fix_new_table_fields_tool.cc
@@ -159,22 +159,22 @@ void FixNewTableFields(int argc, char* argv[])
 		activeGroupKeys.insert(std::pair<std::string, std::pair<TableGroupKey, TableGroupKey>>(
 		    activeGroup.second.first, std::pair<TableGroupKey, TableGroupKey>(activeGroup.second.second, TableGroupKey())));
 
-		if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_BACKBONE)
+		if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_BACKBONE)
 		{
 			activeBackboneGroupName = activeGroup.second.first;
 			__COUT__ << "found activeBackboneGroupName = " << activeBackboneGroupName << __E__;
 		}
-		else if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_CONTEXT)
+		else if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_CONTEXT)
 		{
 			activeContextGroupName = activeGroup.second.first;
 			__COUT__ << "found activeContextGroupName = " << activeContextGroupName << __E__;
 		}
-		else if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_ITERATE)
+		else if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_ITERATE)
 		{
 			activeIterateGroupName = activeGroup.second.first;
 			__COUT__ << "found activeIterateGroupName = " << activeIterateGroupName << __E__;
 		}
-		else if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_CONFIGURATION)
+		else if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_CONFIGURATION)
 		{
 			activeConfigGroupName = activeGroup.second.first;
 			__COUT__ << "found activeConfigGroupName = " << activeConfigGroupName << __E__;
@@ -549,7 +549,7 @@ void FixNewTableFields(int argc, char* argv[])
 	//			activeGroup.second.first << " => " << activeGroup.second.second << __E__;
 	//
 	//	__COUT__<< activeBackboneGroupName << " is the " <<
-	//			ConfigurationManager::ACTIVE_GROUP_NAME_BACKBONE << "." << __E__;
+	//			ConfigurationManager::GROUP_TYPE_NAME_BACKBONE << "." << __E__;
 	//	__COUT__  << "Resulting Active Groups end." << __E__;
 
 	// reload the active backbone (using activeGroupKeys)
@@ -792,7 +792,7 @@ void FixNewTableFields(int argc, char* argv[])
 	for(const auto& activeGroup : activeGroupKeys)
 		__COUT__ << "\t" << activeGroup.first << ": " << activeGroup.second.first << " => " << activeGroup.second.second << __E__;
 
-	__COUT__ << activeBackboneGroupName << " is the " << ConfigurationManager::ACTIVE_GROUP_NAME_BACKBONE << "." << __E__;
+	__COUT__ << activeBackboneGroupName << " is the " << ConfigurationManager::GROUP_TYPE_NAME_BACKBONE << "." << __E__;
 	__COUT__ << "Resulting Active Groups end." << __E__;
 
 CLEAN_UP:

--- a/tools/otsdaq_flatten_system_aliases.cc
+++ b/tools/otsdaq_flatten_system_aliases.cc
@@ -180,25 +180,25 @@ void FlattenActiveSystemAliasTableGroups(int argc, char* argv[])
 		activeGroupKeys.insert(std::pair<std::string, std::pair<TableGroupKey, TableGroupKey>>(
 		    activeGroup.second.first, std::pair<TableGroupKey, TableGroupKey>(activeGroup.second.second, TableGroupKey())));
 
-		if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_BACKBONE)
+		if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_BACKBONE)
 		{
 			activeBackboneGroupName = activeGroup.second.first;
 			__COUT__ << "found activeBackboneGroupName = " << activeBackboneGroupName << std::endl;
 			foundAnyActiveGroups = true;
 		}
-		else if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_CONTEXT)
+		else if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_CONTEXT)
 		{
 			activeContextGroupName = activeGroup.second.first;
 			__COUT__ << "found activeContextGroupName = " << activeContextGroupName << std::endl;
 			foundAnyActiveGroups = true;
 		}
-		else if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_ITERATE)
+		else if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_ITERATE)
 		{
 			activeIterateGroupName = activeGroup.second.first;
 			__COUT__ << "found activeIterateGroupName = " << activeIterateGroupName << std::endl;
 			foundAnyActiveGroups = true;
 		}
-		else if(activeGroup.first == ConfigurationManager::ACTIVE_GROUP_NAME_CONFIGURATION)
+		else if(activeGroup.first == ConfigurationManager::GROUP_TYPE_NAME_CONFIGURATION)
 		{
 			activeConfigGroupName = activeGroup.second.first;
 			__COUT__ << "found activeConfigGroupName = " << activeConfigGroupName << std::endl;
@@ -618,7 +618,7 @@ void FlattenActiveSystemAliasTableGroups(int argc, char* argv[])
 	// std::endl;
 	//
 	//	__COUT__<< activeBackboneGroupName << " is the " <<
-	//			ConfigurationManager::ACTIVE_GROUP_NAME_BACKBONE << "." << std::endl;
+	//			ConfigurationManager::GROUP_TYPE_NAME_BACKBONE << "." << std::endl;
 	//	std::cout << "\n\n" << __COUT_HDR_FL__ << "Resulting Active Groups end." <<
 	// std::endl;
 
@@ -821,7 +821,7 @@ void FlattenActiveSystemAliasTableGroups(int argc, char* argv[])
 	for(const auto& activeGroup : activeGroupKeys)
 		__COUT__ << "------------ " << activeGroup.first << ": " << activeGroup.second.first << " => " << activeGroup.second.second << std::endl;
 
-	__COUT__ << activeBackboneGroupName << " is the " << ConfigurationManager::ACTIVE_GROUP_NAME_BACKBONE << "." << std::endl;
+	__COUT__ << activeBackboneGroupName << " is the " << ConfigurationManager::GROUP_TYPE_NAME_BACKBONE << "." << std::endl;
 	std::cout << "\n\n" << __COUT_HDR_FL__ << "Resulting Active Groups end." << std::endl;
 
 CLEAN_UP:


### PR DESCRIPTION
Gennadiy instructed me that DatabaseConfigurationInterface::getTableGroupMembers is currently an expensive operation (taking 1-4 seconds for remote mongodb interactions per call), so this pull request parallelizes these calls to mongodb for group aliases requests.