### PR TITLE
Add debug statements and comment out line causing seg-fault in TCP usage

### DIFF
--- a/otsdaq/NetworkUtilities/TCPClientBase.cc
+++ b/otsdaq/NetworkUtilities/TCPClientBase.cc
@@ -56,7 +56,8 @@ bool TCPClientBase::connect(int retry, unsigned int sleepMilliSeconds)
 	int totalTries = retry;
 	while(!fConnected && (unsigned int)retry-- > 0)
 	{
-		std::cout << __PRETTY_FUNCTION__ << "Trying to connect" << std::endl;
+		std::cout << __PRETTY_FUNCTION__ << "Trying to connect with socket ID "
+			  << getSocketId() << std::endl;
 		TCPSocket::open();
 		status = ::connect(getSocketId(),
 		                   (struct sockaddr*)&serverSocketAddress,

--- a/otsdaq/NetworkUtilities/TCPServerBase.cc
+++ b/otsdaq/NetworkUtilities/TCPServerBase.cc
@@ -103,11 +103,18 @@ int TCPServerBase::accept(bool blocking)
 		//__COUT__ << "Number of connected clients: " << fConnectedClients.size() << std::endl;
 		// clientSocket = ::accept4(getSocketId(),(struct sockaddr *)&clientAddress,  &clientAddressSize, 0);
 		// unsigned counter = 0;
+                __COUT__ << "Client list on input:\n";
+                for(auto it = fConnectedClients.begin(); it != fConnectedClients.end(); it++) {
+                  __COUT__ << " --> Client: " << it->first << " : " << it->second << std::endl;
+                }
 		while(true)
 		{
 			clientSocket = ::accept(
 			    getSocketId(), (struct sockaddr*)&clientAddress, &clientAddressSize);
-			pingActiveClients();  // This message is to check if there are clients that disconnected and, if so, they are removed from the client list
+			__COUT__ << ": clientSocket returned = " << clientSocket << std::endl;
+
+			//FIXME: Commenting out this line to avoid seg-fault in the case there are two clients connecting from the same process...
+			// pingActiveClients();  // This message is to check if there are clients that disconnected and, if so, they are removed from the client list
 			if(fAccept && fMaxNumberOfClients > 0 &&
 			   fConnectedClients.size() >= fMaxNumberOfClients)
 			{
@@ -335,14 +342,26 @@ void TCPServerBase::broadcast(const std::vector<uint16_t>& message)
 	{
 		try
 		{
-			dynamic_cast<TCPTransmitterSocket*>(it->second)->send(message);
+		  if(it->second) {
+		    dynamic_cast<TCPTransmitterSocket*>(it->second)->send(message);
+		  } else {
+		    __COUT__ << ": Bad client definition, deleting the entry...\n";
+		    if(fConnectedClientsFuture.find(it->first) != fConnectedClientsFuture.end()) {
+		      __COUT__ << "Removing client entry from future connected clients list\n";
+		      fConnectedClientsFuture.erase(fConnectedClientsFuture.find(it->first));
+		    }
+		    fConnectedClients.erase(it--);
+		  }
 		}
 		catch(const std::exception& e)
 		{
 			// __COUT__ << "This should only happen with the TCPSubscribeServer because it doesn't keep track of the connected clients..." << std::endl;
-			// __COUT__ << "Error: " << e.what() << std::endl;
-			if(fConnectedClientsFuture.find(it->first) != fConnectedClientsFuture.end())
-				fConnectedClientsFuture.erase(fConnectedClientsFuture.find(it->first));
+			__COUT__ << "Error: " << e.what() << std::endl;
+			if(fConnectedClientsFuture.find(it->first) != fConnectedClientsFuture.end()) {
+			  __COUT__ << "Removing client entry from future connected clients list\n";
+			  fConnectedClientsFuture.erase(fConnectedClientsFuture.find(it->first));
+			}
+			__COUT__ << "Removing client entry from connected clients list\n";
 			delete it->second;
 			fConnectedClients.erase(it--);
 		}
@@ -354,18 +373,31 @@ void TCPServerBase::pingActiveClients()
 {
 	for(auto it = fConnectedClients.begin(); it != fConnectedClients.end(); it++)
 	{
+                __COUT__ << "Pinging client " << it->first << " : " << it->second << std::endl;
 		try
 		{
-			dynamic_cast<TCPTransmitterSocket*>(it->second)->send("", 0, true);
+		  if(it->second) {
+		    dynamic_cast<TCPTransmitterSocket*>(it->second)->send("", 0, true);
+		  } else {
+		    __COUT__ << ": Bad client definition, deleting the entry...\n";
+		    if(fConnectedClientsFuture.find(it->first) != fConnectedClientsFuture.end()) {
+		      __COUT__ << "Removing client entry from future connected clients list\n";
+		      fConnectedClientsFuture.erase(fConnectedClientsFuture.find(it->first));
+		    }
+		    fConnectedClients.erase(it--);
+		  }
 		}
 		catch(const std::exception& e)
 		{
 			// __COUT__ << "I don't think that this error is possible because I close the socket when I get disconnected...if you see this then you should
 			// contact Lorenzo Uplegger" << std::endl;
 			// __COUT__ << "This should only happen with the TCPSubscribeServer because it doesn't keep track of the connected clients..." << std::endl;
-			// __COUT__ << "Error: " << e.what() << std::endl;
-			if(fConnectedClientsFuture.find(it->first) != fConnectedClientsFuture.end())
-				fConnectedClientsFuture.erase(fConnectedClientsFuture.find(it->first));
+			__COUT__ << "Error: " << e.what() << std::endl;
+			if(fConnectedClientsFuture.find(it->first) != fConnectedClientsFuture.end()) {
+			  __COUT__ << "Removing client entry from future connected clients list\n";
+			  fConnectedClientsFuture.erase(fConnectedClientsFuture.find(it->first));
+			}
+			__COUT__ << "Removing client entry from connected clients list\n";
 			delete it->second;
 			fConnectedClients.erase(it--);
 		}


### PR DESCRIPTION
Adding debug statements in the TCP usage. Commenting out a ping call that leads to a seg-fault when multiple clients from the same process are connected.