### PR TITLE
[FiniteStateMachine] Add tryTransition

### DIFF
--- a/otsdaq/FiniteStateMachine/FiniteStateMachine.cc
+++ b/otsdaq/FiniteStateMachine/FiniteStateMachine.cc
@@ -184,6 +184,38 @@ std::string FiniteStateMachine::getTransitionFinalStateName(const std::string& t
 	return getStateName(getTransitionFinalState(transition));
 }
 
+bool FiniteStateMachine::assertValidTransition(const std::string& transition, bool fail)
+{
+	std::map<std::string, toolbox::fsm::State> transitions =
+		getTransitions(getCurrentState());
+	if(transitions.find(transition) == transitions.end())
+	{
+		inTransition_ = false;
+		std::ostringstream error;
+		error << transition
+		      << " is not in the list of the transitions from current state "
+		      << getStateName(getCurrentState());
+		__GEN_COUT_ERR__ << error.str() << __E__;
+		__GEN_COUTV__(getErrorMessage());
+		if(fail)
+			XCEPT_RAISE(toolbox::fsm::exception::Exception, error.str());
+		//__GEN_COUT__ << error << __E__;
+		//		__GEN_COUT__ << "Transition?" << inTransition_ << __E__;
+		return false;
+	}
+	return true;
+}
+
+bool FiniteStateMachine::tryTransition(const std::string& transition)
+{
+	if(!FiniteStateMachine::assertValidTransition(transition, false))
+	{
+		return false;
+	}
+
+	return FiniteStateMachine::execTransition(transition);
+}
+
 //==============================================================================
 bool FiniteStateMachine::execTransition(const std::string& transition)
 {
@@ -278,18 +310,9 @@ bool FiniteStateMachine::execTransition(const std::string&            transition
 
 	std::map<std::string, toolbox::fsm::State> transitions =
 	    getTransitions(getCurrentState());
-	if(transitions.find(transition) == transitions.end())
+
+	if(!FiniteStateMachine::assertValidTransition(transition, true))
 	{
-		inTransition_ = false;
-		std::ostringstream error;
-		error << transition
-		      << " is not in the list of the transitions from current state "
-		      << getStateName(getCurrentState());
-		__GEN_COUT_ERR__ << error.str() << __E__;
-		__GEN_COUTV__(getErrorMessage());
-		XCEPT_RAISE(toolbox::fsm::exception::Exception, error.str());
-		//__GEN_COUT__ << error << __E__;
-		//		__GEN_COUT__ << "Transition?" << inTransition_ << __E__;
 		return false;
 	}
 

--- a/otsdaq/FiniteStateMachine/FiniteStateMachine.h
+++ b/otsdaq/FiniteStateMachine/FiniteStateMachine.h
@@ -58,6 +58,7 @@ class FiniteStateMachine : public toolbox::fsm::FiniteStateMachine
 
 	const xoap::MessageReference& 	getCurrentMessage			(void) { return theMessage_; }
 
+	bool 							tryTransition				(const std::string& transition);
 	bool 							execTransition				(const std::string& transition);
 	bool 							execTransition				(const std::string& transition, const xoap::MessageReference& message);
 	bool 							isInTransition				(void);
@@ -94,6 +95,7 @@ class FiniteStateMachine : public toolbox::fsm::FiniteStateMachine
 
 
   private:
+	bool 					assertValidTransition		(const std::string& transition, bool fail = true);
 };
 // clang-format on
 }  // namespace ots


### PR DESCRIPTION
## Context:
- In the Console view, users can configure message filters that trigger actions. Some of these are FSM-related, such as triggering `Halt`, `Stop`, and `Pause` transitions. These three, however, require the FSM to have been previously configured and set to running which isn't necessarily always the case.
- There isn't a request mechanism to handle the FSM, and every Supervisor that inherits from `BaseSupervisor` has direct access to the FSM.

## Proposed solution:
- In contrast to `execTransition`, which fails with an error if the transition isn't valid, the function `tryTransition` first checks the validity of the transition and can be set to either fail or not fail.
- This could be used in other Supervisors to attempt transitions without having to do annoying checks of the current state, which might be configured in non-standard ways

## Request for feedback:
- Is this of any value at all, or is it be best to just check the current state in the `ConsoleSupervisor` code instead of modifying this?

## Pending work:
- [ ] Confirm whether or not `execTransition` really fails irrecoverably on an invalid transition
- [ ] Ensure transition propagates to FSM GUI