### PR TITLE
Update comment box data storage for long comments

### DIFF
--- a/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
+++ b/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
@@ -2880,8 +2880,7 @@ void GatewaySupervisor::stateMachineXgiHandler(xgi::Input* in, xgi::Output* out)
 		return;  // access failed
 
 	std::string fsmName       = CgiDataUtilities::getData(cgiIn, "fsmName");
-	std::string fsmWindowName = CgiDataUtilities::postData(cgiIn, "fsmWindowName");
-	// std::string fsmWindowName = CgiDataUtilities::getData(cgiIn, "fsmWindowName");
+	std::string fsmWindowName = CgiDataUtilities::getOrPostData(cgiIn, "fsmWindowName");
 	fsmWindowName             = StringMacros::decodeURIComponent(fsmWindowName);
 	std::string currentState  = theStateMachine_.getCurrentStateName();
 

--- a/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
+++ b/otsdaq/GatewaySupervisor/GatewaySupervisor.cc
@@ -2880,7 +2880,8 @@ void GatewaySupervisor::stateMachineXgiHandler(xgi::Input* in, xgi::Output* out)
 		return;  // access failed
 
 	std::string fsmName       = CgiDataUtilities::getData(cgiIn, "fsmName");
-	std::string fsmWindowName = CgiDataUtilities::getData(cgiIn, "fsmWindowName");
+	std::string fsmWindowName = CgiDataUtilities::postData(cgiIn, "fsmWindowName");
+	// std::string fsmWindowName = CgiDataUtilities::getData(cgiIn, "fsmWindowName");
 	fsmWindowName             = StringMacros::decodeURIComponent(fsmWindowName);
 	std::string currentState  = theStateMachine_.getCurrentStateName();
 


### PR DESCRIPTION
Long comments were causing errors, so I moved the comment to postData. In connection to PR https://github.com/art-daq/otsdaq-utilities/pull/162