### PR TITLE
Adjust ARTDAQMetricTableInfo.xml to match ARTDAQTableBase.cc

### DIFF
--- a/data-core/TableInfo/ARTDAQ/ARTDAQMetricTableInfo.xml
+++ b/data-core/TableInfo/ARTDAQ/ARTDAQMetricTableInfo.xml
@@ -7,7 +7,9 @@
 				<COLUMN Type="OnOff" 	 Name="Status" 	 StorageName="STATUS" 		DataType="VARCHAR2" 		DataChoices=""/>
 				<COLUMN Type="Data" 	 Name="metricKey" 	 StorageName="METRIC_KEY" 		DataType="VARCHAR2" 		DataChoices=""/>
 				<COLUMN Type="Data" 	 Name="metricPluginType" 	 StorageName="METRIC_PLUGIN_TYPE" 		DataType="VARCHAR2" 		DataChoices=""/>
-				<COLUMN Type="Data" 	 Name="metricLevel" 	 StorageName="METRIC_LEVEL" 		DataType="VARCHAR2" 		DataChoices=""/>
+				<COLUMN Type="Data" 	 Name="metricLevelString" 	 StorageName="METRIC_LEVEL_STRING" 		DataType="VARCHAR2" 		DataChoices=""/>
+                <COLUMN Type="TrueFalse" 	 Name="sendSystemMetrics" 	 StorageName="SEND_SYSTEM_METRICS" 		DataType="STRING" 		DataChoices=""/>
+                <COLUMN Type="TrueFalse" 	 Name="sendProcessMetrics" 	 StorageName="SEND_PROCESS_METRICS" 		DataType="STRING" 		DataChoices=""/>
 				<COLUMN Type="ChildLink-metricParameters" 	 Name="metricParametersLink" 	 StorageName="METRIC_PARAMETERS_LINK" 		DataType="VARCHAR2" 		DataChoices="arbitraryBool=0,NO_LINK,ARTDAQMetricParameterTable"/>
 				<COLUMN Type="ChildLinkGroupID-metricParameters" 	 Name="metricParametersLinkGroupID" 	 StorageName="METRIC_PARAMETERS_LINK_GROUP_ID" 		DataType="VARCHAR2" 		DataChoices=""/>
 				<COLUMN Type="Comment" 	 Name="CommentDescription" 	 StorageName="COMMENT_DESCRIPTION" 		DataType="VARCHAR2" 		DataChoices=""/>


### PR DESCRIPTION
The current table definition `ARTDAQMetricTableInfo.xml ` doesn't match the options in `ARTDAQTableBase.cc`, these changes align the table definition to the implementation. For `sendSystemMetrics` and `sendProcessMetrics` the defaults could be used (and the corresponding table could be just added to mu2e), however `metricLevel` was changed to `metricLevelString`. I think we should avoid having table fields that are not reflected in the code. From my point of view, this motivates me to update the table in otsdaq (rather than "just" adding it to otsdaq-mu2e-config). Will this cause problems for configurations that don't have these fields? 

mu2e Data_trigger seems to be already using the "updated" table definition. 