### PR TITLE
Fixed bug Simon found where tables with Scratch versions would get wr…

### DIFF
--- a/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
@@ -164,8 +164,8 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 				              << retries << __E__;
 				if(++retries > 3)  //give up
 					throw;
-				// newVersion = TableVersion::getNextVersion(
-				// 	newVersion);  //increment table version
+				newVersion = TableVersion::getNextVersion(
+					newVersion);  //increment table version
 				tableView->setVersion(newVersion);
 				__COUT__ << "New version for table: " << *tableView << " found as "
 				         << newVersion << __E__;

--- a/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
@@ -164,8 +164,8 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 				              << retries << __E__;
 				if(++retries > 3)  //give up
 					throw;
-				newVersion = TableVersion::getNextVersion(
-					newVersion);  //increment table version
+				newVersion =
+				    TableVersion::getNextVersion(newVersion);  //increment table version
 				tableView->setVersion(newVersion);
 				__COUT__ << "New version for table: " << *tableView << " found as "
 				         << newVersion << __E__;

--- a/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
@@ -82,8 +82,7 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 {
 	if(!temporaryVersion.isTemporaryVersion() || !table->isStored(temporaryVersion))
 	{
-		std::cout << __COUT_HDR_FL__
-		          << "Invalid temporary version number: " << temporaryVersion
+		__COUT__ << "Invalid temporary version number: " << temporaryVersion
 		          << std::endl;
 		return TableVersion();  // return INVALID
 	}
@@ -95,18 +94,24 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 	bool rewriteableExists = false;
 
 	std::set<TableVersion> versions = getVersions(table);
+	__COUTTV__(StringMacros::setToString(versions));
 	if(newVersion == TableVersion::INVALID)
 	{
+		if(versions.size())		
+			__COUTTV__(*(versions.rbegin()));
+		if(versions.size() > 1)
+			__COUTTV__(*(++versions.rbegin()));
+
 		if(versions
 		       .size() &&  // 1 more than last version, if any non-scratch versions exist
 		   *(versions.rbegin()) != TableVersion(TableVersion::SCRATCH))
 			newVersion = TableVersion::getNextVersion(*(versions.rbegin()));
 		else if(versions.size() >
 		        1)  // if scratch exists, take 1 more than second to last version
-			newVersion = TableVersion::getNextVersion(*(--(versions.rbegin())));
+			newVersion = TableVersion::getNextVersion(*(++(versions.rbegin()))); //NOTE: ++ is reverse for a reverse_iterator!!
 		else
 			newVersion = TableVersion::DEFAULT;
-		std::cout << __COUT_HDR_FL__ << "Next available version number is " << newVersion
+		__COUT__ << "Next available version number is " << newVersion
 		          << std::endl;
 		//
 		//		//for sanity check, compare with config's idea of next version
@@ -120,7 +125,7 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 	}
 	else if(versions.find(newVersion) != versions.end())
 	{
-		std::cout << __COUT_HDR_FL__ << "newVersion(" << newVersion << ") already exists!"
+		__COUT__ << "newVersion(" << newVersion << ") already exists!"
 		          << std::endl;
 		rewriteableExists = newVersion == TableVersion::SCRATCH;
 
@@ -128,12 +133,11 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 		if(!rewriteableExists || ConfigurationInterface::isVersionTrackingEnabled())
 		{
 			__SS__ << ("New version already exists!") << std::endl;
-			std::cout << __COUT_HDR_FL__ << ss.str();
 			__SS_THROW__;
 		}
 	}
 
-	std::cout << __COUT_HDR_FL__ << "Version number to save is " << newVersion
+	__COUT__ << "Version number to save is " << newVersion
 	          << std::endl;
 
 	// copy to new version
@@ -142,8 +146,45 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 	// save to disk
 	//	only allow overwrite if version tracking is disabled AND the rewriteable version
 	//		already exists.
-	saveActiveVersion(
-	    table, !ConfigurationInterface::isVersionTrackingEnabled() && rewriteableExists);
+	bool overwrite = !ConfigurationInterface::isVersionTrackingEnabled() && rewriteableExists;
+	uint16_t retries = overwrite?4:0; //only allow retries if not overwriting
+	auto tableView = table->getViewP();
+	while(1)
+	{
+		try
+		{
+			saveActiveVersion(
+				table, overwrite);
+		}
+		catch(const std::runtime_error& e)
+		{
+			__COUT__ << "Caught runtime_error exception during table save."
+							<< __E__;
+			if(std::string(e.what()).find("there was a collision") !=
+				std::string::npos)
+			{
+				__COUT_WARN__
+					<< "There was a collision saving the new table "
+					<< *tableView << "(" << newVersion
+					<< "), trying incremented table version... retries="
+					<< retries << __E__;
+				if(++retries > 3)  //give up
+					throw;
+				// newVersion = TableVersion::getNextVersion(
+				// 	newVersion);  //increment table version
+				tableView->setVersion(newVersion);
+				__COUT__ << "New version for table: " << *tableView
+							<< " found as " << newVersion << __E__;
+				continue;
+			}
+			else
+				throw;
+		}
+
+		__COUT__ << "Created table: " << *tableView << "-v"
+						<< newVersion << __E__;
+		break;
+	}  //end collission retry loop
 
 	return newVersion;
 }  //end saveNewVersion()

--- a/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationInterface.cc
@@ -82,8 +82,7 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 {
 	if(!temporaryVersion.isTemporaryVersion() || !table->isStored(temporaryVersion))
 	{
-		__COUT__ << "Invalid temporary version number: " << temporaryVersion
-		          << std::endl;
+		__COUT__ << "Invalid temporary version number: " << temporaryVersion << std::endl;
 		return TableVersion();  // return INVALID
 	}
 
@@ -97,7 +96,7 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 	__COUTTV__(StringMacros::setToString(versions));
 	if(newVersion == TableVersion::INVALID)
 	{
-		if(versions.size())		
+		if(versions.size())
 			__COUTTV__(*(versions.rbegin()));
 		if(versions.size() > 1)
 			__COUTTV__(*(++versions.rbegin()));
@@ -108,11 +107,11 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 			newVersion = TableVersion::getNextVersion(*(versions.rbegin()));
 		else if(versions.size() >
 		        1)  // if scratch exists, take 1 more than second to last version
-			newVersion = TableVersion::getNextVersion(*(++(versions.rbegin()))); //NOTE: ++ is reverse for a reverse_iterator!!
+			newVersion = TableVersion::getNextVersion(
+			    *(++(versions.rbegin())));  //NOTE: ++ is reverse for a reverse_iterator!!
 		else
 			newVersion = TableVersion::DEFAULT;
-		__COUT__ << "Next available version number is " << newVersion
-		          << std::endl;
+		__COUT__ << "Next available version number is " << newVersion << std::endl;
 		//
 		//		//for sanity check, compare with config's idea of next version
 		//		TableVersion baseNextVersion = table->getNextVersion();
@@ -125,8 +124,7 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 	}
 	else if(versions.find(newVersion) != versions.end())
 	{
-		__COUT__ << "newVersion(" << newVersion << ") already exists!"
-		          << std::endl;
+		__COUT__ << "newVersion(" << newVersion << ") already exists!" << std::endl;
 		rewriteableExists = newVersion == TableVersion::SCRATCH;
 
 		// throw error if version already exists and this is not the rewriteable version
@@ -137,8 +135,7 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 		}
 	}
 
-	__COUT__ << "Version number to save is " << newVersion
-	          << std::endl;
+	__COUT__ << "Version number to save is " << newVersion << std::endl;
 
 	// copy to new version
 	table->changeVersionAndActivateView(temporaryVersion, newVersion);
@@ -146,43 +143,39 @@ TableVersion ConfigurationInterface::saveNewVersion(TableBase*   table,
 	// save to disk
 	//	only allow overwrite if version tracking is disabled AND the rewriteable version
 	//		already exists.
-	bool overwrite = !ConfigurationInterface::isVersionTrackingEnabled() && rewriteableExists;
-	uint16_t retries = overwrite?4:0; //only allow retries if not overwriting
-	auto tableView = table->getViewP();
+	bool overwrite =
+	    !ConfigurationInterface::isVersionTrackingEnabled() && rewriteableExists;
+	uint16_t retries   = overwrite ? 4 : 0;  //only allow retries if not overwriting
+	auto     tableView = table->getViewP();
 	while(1)
 	{
 		try
 		{
-			saveActiveVersion(
-				table, overwrite);
+			saveActiveVersion(table, overwrite);
 		}
 		catch(const std::runtime_error& e)
 		{
-			__COUT__ << "Caught runtime_error exception during table save."
-							<< __E__;
-			if(std::string(e.what()).find("there was a collision") !=
-				std::string::npos)
+			__COUT__ << "Caught runtime_error exception during table save." << __E__;
+			if(std::string(e.what()).find("there was a collision") != std::string::npos)
 			{
-				__COUT_WARN__
-					<< "There was a collision saving the new table "
-					<< *tableView << "(" << newVersion
-					<< "), trying incremented table version... retries="
-					<< retries << __E__;
+				__COUT_WARN__ << "There was a collision saving the new table "
+				              << *tableView << "(" << newVersion
+				              << "), trying incremented table version... retries="
+				              << retries << __E__;
 				if(++retries > 3)  //give up
 					throw;
 				// newVersion = TableVersion::getNextVersion(
 				// 	newVersion);  //increment table version
 				tableView->setVersion(newVersion);
-				__COUT__ << "New version for table: " << *tableView
-							<< " found as " << newVersion << __E__;
+				__COUT__ << "New version for table: " << *tableView << " found as "
+				         << newVersion << __E__;
 				continue;
 			}
 			else
 				throw;
 		}
 
-		__COUT__ << "Created table: " << *tableView << "-v"
-						<< newVersion << __E__;
+		__COUT__ << "Created table: " << *tableView << "-v" << newVersion << __E__;
 		break;
 	}  //end collission retry loop
 

--- a/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
@@ -1984,7 +1984,7 @@ TableGroupKey ConfigurationManagerRW::saveNewTableGroup(
 						    << groupMetadataTable_ << "(" << newVersion
 						    << "), trying incremented table version... retries="
 						    << retries << __E__;
-						if(++retries > 0)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newVersion = TableVersion::getNextVersion(
 						    newVersion);  //increment table version
@@ -2036,7 +2036,7 @@ TableGroupKey ConfigurationManagerRW::saveNewTableGroup(
 						    << "(" << newKey
 						    << "), trying incremented group key... retries=" << retries
 						    << __E__;
-						if(++retries > 0)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newKey = TableGroupKey::getNextKey(newKey);  //increment group key
 						__GEN_COUT__ << "New Key for group: " << groupName << " found as "

--- a/otsdaq/ConfigurationInterface/Database_configInterface.cc
+++ b/otsdaq/ConfigurationInterface/Database_configInterface.cc
@@ -314,20 +314,7 @@ try
 
 	__COUTTV__(StringMacros::setToString(resultSet));
 
-	//	auto to_set = [](auto const& inputList)
-	//	{
-	//		auto resultSet = std::set<TableVersion>{};
-	//		std::for_each(inputList.begin(), inputList.end(),
-	//				[&resultSet](std::string const& version)
-	//				{ resultSet.insert(std::stol(version, 0, 10)); });
-	//		return resultSet;
-	//	};
-
-	// auto vs = to_set(result);
-	// for(auto &v:vs)
-	//	__COUT__ << "\tversion " << v << __E__;
-
-	return resultSet;  // to_set(result);
+	return resultSet;
 }  //end getVersions()
 catch(std::exception const& e)
 {

--- a/otsdaq/ConfigurationInterface/Database_configInterface.cc
+++ b/otsdaq/ConfigurationInterface/Database_configInterface.cc
@@ -214,7 +214,7 @@ void DatabaseConfigurationInterface::saveActiveVersion(const TableBase* table,
 					{
 						__COUTT__ << "Mismatch at preSaveJSON[" << prec
 						          << "] != postSaveJSON[" << postc << "] ... "
-						          << preSaveJSON[prec] << " != " << postSaveJSON[postc]
+						          << preSaveJSON.substr(prec,30) << " != " << postSaveJSON.substr(postc,30)
 						          << __E__;
 						same = false;
 						break;
@@ -311,6 +311,8 @@ try
 	auto resultSet = std::set<TableVersion>{};
 	for(std::string const& version : result)
 		resultSet.insert(TableVersion(std::stol(version, 0, 10)));
+		
+	__COUTTV__(StringMacros::setToString(resultSet));
 
 	//	auto to_set = [](auto const& inputList)
 	//	{

--- a/otsdaq/ConfigurationInterface/Database_configInterface.cc
+++ b/otsdaq/ConfigurationInterface/Database_configInterface.cc
@@ -214,8 +214,8 @@ void DatabaseConfigurationInterface::saveActiveVersion(const TableBase* table,
 					{
 						__COUTT__ << "Mismatch at preSaveJSON[" << prec
 						          << "] != postSaveJSON[" << postc << "] ... "
-						          << preSaveJSON.substr(prec,30) << " != " << postSaveJSON.substr(postc,30)
-						          << __E__;
+						          << preSaveJSON.substr(prec, 30)
+						          << " != " << postSaveJSON.substr(postc, 30) << __E__;
 						same = false;
 						break;
 					}
@@ -311,7 +311,7 @@ try
 	auto resultSet = std::set<TableVersion>{};
 	for(std::string const& version : result)
 		resultSet.insert(TableVersion(std::stol(version, 0, 10)));
-		
+
 	__COUTTV__(StringMacros::setToString(resultSet));
 
 	//	auto to_set = [](auto const& inputList)

--- a/otsdaq/TableCore/TableBase.cc
+++ b/otsdaq/TableCore/TableBase.cc
@@ -774,13 +774,13 @@ void TableBase::changeVersionAndActivateView(TableVersion temporaryVersion,
 	emplacePair.first->second.copy(tmpIt->second, version, tmpIt->second.getAuthor());
 	setActiveView(version);
 	eraseView(temporaryVersion);  // delete temp version from tableViews_
-}
+} //emd changeVersionAndActivateView()
 
 //==============================================================================
 bool TableBase::isStored(const TableVersion& version) const
 {
 	return (tableViews_.find(version) != tableViews_.end());
-}
+} //end isStored()
 
 //==============================================================================
 bool TableBase::eraseView(TableVersion version)
@@ -795,7 +795,7 @@ bool TableBase::eraseView(TableVersion version)
 	tableViews_.erase(version);
 
 	return true;
-}
+} //end eraseView()
 
 //==============================================================================
 const std::string& TableBase::getTableName(void) const { return tableName_; }
@@ -804,13 +804,13 @@ const std::string& TableBase::getTableName(void) const { return tableName_; }
 const std::string& TableBase::getTableDescription(void) const
 {
 	return tableDescription_;
-}
+} //end getTableDescription()
 
 //==============================================================================
 const TableVersion& TableBase::getViewVersion(void) const
 {
 	return getView().getVersion();
-}
+} //end getViewVersion()
 
 //==============================================================================
 /// latestAndMockupColumnNumberMismatch
@@ -825,7 +825,7 @@ bool TableBase::latestAndMockupColumnNumberMismatch(void) const
 	}
 	// there are no latest non-temporary tables so there is a mismatch (by default)
 	return true;
-}
+} //end latestAndMockupColumnNumberMismatch()
 
 //==============================================================================
 std::set<TableVersion> TableBase::getStoredVersions(void) const
@@ -834,7 +834,7 @@ std::set<TableVersion> TableBase::getStoredVersions(void) const
 	for(auto& configs : tableViews_)
 		retSet.emplace(configs.first);
 	return retSet;
-}
+} //end getStoredVersions()
 
 //==============================================================================
 /// getNumberOfStoredViews
@@ -888,7 +888,7 @@ const TableView& TableBase::getView(
 		__SS_ONLY_THROW__;
 	}
 	return *activeTableView_;
-}
+} //end getView()
 
 //==============================================================================
 TableView* TableBase::getViewP(TableVersion version /* = TableVersion::INVALID */)
@@ -913,7 +913,7 @@ TableView* TableBase::getViewP(TableVersion version /* = TableVersion::INVALID *
 		__SS_ONLY_THROW__;
 	}
 	return activeTableView_;
-}
+} //end getViewP()
 
 //==============================================================================
 TableView* TableBase::getMockupViewP(void) { return &mockupTableView_; }
@@ -925,7 +925,7 @@ void TableBase::setTableName(const std::string& tableName) { tableName_ = tableN
 void TableBase::setTableDescription(const std::string& tableDescription)
 {
 	tableDescription_ = tableDescription;
-}
+} //end setTableDescription()
 
 //==============================================================================
 /// deactivate
@@ -958,7 +958,7 @@ bool TableBase::setActiveView(TableVersion version)
 	}
 
 	return true;
-}
+} //end setActiveView()
 
 //==============================================================================
 /// mergeViews

--- a/otsdaq/TableCore/TableBase.cc
+++ b/otsdaq/TableCore/TableBase.cc
@@ -774,13 +774,13 @@ void TableBase::changeVersionAndActivateView(TableVersion temporaryVersion,
 	emplacePair.first->second.copy(tmpIt->second, version, tmpIt->second.getAuthor());
 	setActiveView(version);
 	eraseView(temporaryVersion);  // delete temp version from tableViews_
-} //emd changeVersionAndActivateView()
+}  //emd changeVersionAndActivateView()
 
 //==============================================================================
 bool TableBase::isStored(const TableVersion& version) const
 {
 	return (tableViews_.find(version) != tableViews_.end());
-} //end isStored()
+}  //end isStored()
 
 //==============================================================================
 bool TableBase::eraseView(TableVersion version)
@@ -795,7 +795,7 @@ bool TableBase::eraseView(TableVersion version)
 	tableViews_.erase(version);
 
 	return true;
-} //end eraseView()
+}  //end eraseView()
 
 //==============================================================================
 const std::string& TableBase::getTableName(void) const { return tableName_; }
@@ -804,13 +804,13 @@ const std::string& TableBase::getTableName(void) const { return tableName_; }
 const std::string& TableBase::getTableDescription(void) const
 {
 	return tableDescription_;
-} //end getTableDescription()
+}  //end getTableDescription()
 
 //==============================================================================
 const TableVersion& TableBase::getViewVersion(void) const
 {
 	return getView().getVersion();
-} //end getViewVersion()
+}  //end getViewVersion()
 
 //==============================================================================
 /// latestAndMockupColumnNumberMismatch
@@ -825,7 +825,7 @@ bool TableBase::latestAndMockupColumnNumberMismatch(void) const
 	}
 	// there are no latest non-temporary tables so there is a mismatch (by default)
 	return true;
-} //end latestAndMockupColumnNumberMismatch()
+}  //end latestAndMockupColumnNumberMismatch()
 
 //==============================================================================
 std::set<TableVersion> TableBase::getStoredVersions(void) const
@@ -834,7 +834,7 @@ std::set<TableVersion> TableBase::getStoredVersions(void) const
 	for(auto& configs : tableViews_)
 		retSet.emplace(configs.first);
 	return retSet;
-} //end getStoredVersions()
+}  //end getStoredVersions()
 
 //==============================================================================
 /// getNumberOfStoredViews
@@ -888,7 +888,7 @@ const TableView& TableBase::getView(
 		__SS_ONLY_THROW__;
 	}
 	return *activeTableView_;
-} //end getView()
+}  //end getView()
 
 //==============================================================================
 TableView* TableBase::getViewP(TableVersion version /* = TableVersion::INVALID */)
@@ -913,7 +913,7 @@ TableView* TableBase::getViewP(TableVersion version /* = TableVersion::INVALID *
 		__SS_ONLY_THROW__;
 	}
 	return activeTableView_;
-} //end getViewP()
+}  //end getViewP()
 
 //==============================================================================
 TableView* TableBase::getMockupViewP(void) { return &mockupTableView_; }
@@ -925,7 +925,7 @@ void TableBase::setTableName(const std::string& tableName) { tableName_ = tableN
 void TableBase::setTableDescription(const std::string& tableDescription)
 {
 	tableDescription_ = tableDescription;
-} //end setTableDescription()
+}  //end setTableDescription()
 
 //==============================================================================
 /// deactivate
@@ -958,7 +958,7 @@ bool TableBase::setActiveView(TableVersion version)
 	}
 
 	return true;
-} //end setActiveView()
+}  //end setActiveView()
 
 //==============================================================================
 /// mergeViews

--- a/tools/otsdaq_import_groups_from_export_path.cc
+++ b/tools/otsdaq_import_groups_from_export_path.cc
@@ -461,7 +461,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 						    << importedBackboneGroupName << "(" << newKey
 						    << "), trying incremented group key... retries=" << retries
 						    << __E__;
-						if(++retries > 10)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newKey = TableGroupKey::getNextKey(newKey);  //increment group key
 						__COUT__ << "New Key for group: " << importedBackboneGroupName
@@ -953,7 +953,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 							    << *tableView << "(" << newAssignedVersion
 							    << "), trying incremented table version... retries="
 							    << retries << __E__;
-							if(++retries > 10)  //give up
+							if(++retries > 3)  //give up
 								throw;
 							newAssignedVersion = TableVersion::getNextVersion(
 							    newAssignedVersion);  //increment table version
@@ -966,7 +966,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 							throw;
 					}
 
-					__COUT__ << "Created table: " << tableView << "-v"
+					__COUT__ << "Created table: " << *tableView << "-v"
 					         << newAssignedVersion << __E__;
 					break;
 				}  //end collission retry loop
@@ -1078,7 +1078,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 					    << group.first.first << "(" << newKey
 					    << "), trying incremented group key... retries=" << retries
 					    << __E__;
-					if(++retries > 10)  //give up
+					if(++retries > 3)  //give up
 						throw;
 					newKey = TableGroupKey::getNextKey(newKey);  //increment group key
 					__COUT__ << "New Key for group: " << group.first.first << " found as "
@@ -1303,7 +1303,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 						              << *cfgView << "(" << newVersion
 						              << "), trying incremented table version... retries="
 						              << retries << __E__;
-						if(++retries > 10)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newVersion = TableVersion::getNextVersion(
 						    newVersion);  //increment table version
@@ -1462,7 +1462,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 						              << *cfgView << "(" << newVersion
 						              << "), trying incremented table version... retries="
 						              << retries << __E__;
-						if(++retries > 10)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newVersion = TableVersion::getNextVersion(
 						    newVersion);  //increment table version
@@ -1581,7 +1581,7 @@ void ImportTableGroupsFromPath(int argc, char* argv[])
 						    << activeBackboneGroupName << "(" << newKey
 						    << "), trying incremented group key... retries=" << retries
 						    << __E__;
-						if(++retries > 10)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newKey = TableGroupKey::getNextKey(newKey);  //increment group key
 						__COUT__ << "New Key for group: " << activeBackboneGroupName

--- a/tools/otsdaq_import_system_aliases.cc
+++ b/tools/otsdaq_import_system_aliases.cc
@@ -629,7 +629,7 @@ void ImportSystemAliasTableGroups(int argc, char* argv[])
 							    << *cfgView << "(" << newVersion
 							    << "), trying incremented table version... retries="
 							    << retries << __E__;
-							if(++retries > 10)  //give up
+							if(++retries > 3)  //give up
 								throw;
 							newVersion = TableVersion::getNextVersion(
 							    newVersion);  //increment table version
@@ -725,7 +725,7 @@ void ImportSystemAliasTableGroups(int argc, char* argv[])
 						              << groupMetadataTable << "(" << newVersion
 						              << "), trying incremented table version... retries="
 						              << retries << __E__;
-						if(++retries > 10)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newVersion = TableVersion::getNextVersion(
 						    newVersion);  //increment table version
@@ -778,7 +778,7 @@ void ImportSystemAliasTableGroups(int argc, char* argv[])
 						    << groupPair.first.first << "(" << newKey
 						    << "), trying incremented group key... retries=" << retries
 						    << __E__;
-						if(++retries > 10)  //give up
+						if(++retries > 3)  //give up
 							throw;
 						newKey = TableGroupKey::getNextKey(newKey);  //increment group key
 						__COUT__ << "New Key for group: " << groupPair.first.first
@@ -1025,7 +1025,7 @@ void ImportSystemAliasTableGroups(int argc, char* argv[])
 					    << "(" << newVersion
 					    << "), trying incremented table version... retries=" << retries
 					    << __E__;
-					if(++retries > 10)  //give up
+					if(++retries > 3)  //give up
 						throw;
 					newVersion = TableVersion::getNextVersion(
 					    newVersion);  //increment table version
@@ -1077,7 +1077,7 @@ void ImportSystemAliasTableGroups(int argc, char* argv[])
 					    << "(" << newVersion
 					    << "), trying incremented table version... retries=" << retries
 					    << __E__;
-					if(++retries > 10)  //give up
+					if(++retries > 3)  //give up
 						throw;
 					newVersion = TableVersion::getNextVersion(
 					    newVersion);  //increment table version
@@ -1131,7 +1131,7 @@ void ImportSystemAliasTableGroups(int argc, char* argv[])
 					    << activeBackboneGroupName << "(" << newKey
 					    << "), trying incremented group key... retries=" << retries
 					    << __E__;
-					if(++retries > 10)  //give up
+					if(++retries > 3)  //give up
 						throw;
 					newKey = TableGroupKey::getNextKey(newKey);  //increment group key
 					__COUT__ << "New Key for group: " << activeBackboneGroupName


### PR DESCRIPTION
…ong next version to save - this was due to -- operation a reverse_iterator which goes in the forward direction, instead of backward as needed. Also, fixed some printout messages, and changed number of retries to 3.