### PR TITLE
Specify the TCP listen port for OM art jobs to avoid issues with

### DIFF
--- a/data-core/TableInfo/ARTDAQ/ARTDAQOnlineMonitorTableInfo.xml
+++ b/data-core/TableInfo/ARTDAQ/ARTDAQOnlineMonitorTableInfo.xml
@@ -7,6 +7,7 @@
 				<COLUMN Type="OnOff" 	 Name="Status" 	 StorageName="STATUS" 		DataType="STRING" 		DataChoices=""/>
 				<COLUMN Type="Data" 	 Name="ExecutionHostname" 	 StorageName="EXECUTION_HOSTNAME" 		DataType="STRING" 		DataChoices=""/>
         <COLUMN Type="Data" 	 Name="MonitorID" 	 StorageName="MONITOR_ID" 		DataType="NUMBER" 		DataChoices=""/>
+        <COLUMN Type="Data" 	 Name="MonitorTCPListenPort" 	 StorageName="MONITOR_TCP_LISTEN_PORT" 		DataType="NUMBER" 		DataChoices=""/>
         <COLUMN Type="Data" 	 Name="max_fragment_size_words" 	 StorageName="MAX_FRAGMENT_SIZE_WORDS" 		DataType="NUMBER" 		DataChoices=""/>
         <COLUMN Type="Data" 	 Name="transfer_plugin_type" 	 StorageName="TRANSFER_PLUGIN_TYPE" 		DataType="STRING" 		DataChoices="arbitraryBool=0,Autodetect,Shmem,TCPSocket"/>
         <COLUMN Type="Data" 	 Name="dispatcher_path" 	 StorageName="DISPATCHER_PATH" 		DataType="STRING" 		DataChoices=""/>

--- a/otsdaq/TablePlugins/ARTDAQTableBase/ARTDAQTableBase.cc
+++ b/otsdaq/TablePlugins/ARTDAQTableBase/ARTDAQTableBase.cc
@@ -1325,6 +1325,8 @@ void ARTDAQTableBase::outputOnlineMonitorFHICL(const ConfigurationTree& monitorN
 			OUT << "source.commanderPluginType: xmlrpc\n";
 
 			int om_rank = monitorNode.getNode("MonitorID").getValue<int>();
+            int om_tcp_listen_port =
+			    monitorNode.getNode("MonitorTCPListenPort").getValue<int>();
 			int disp_fake_rank =
 			    dispatcherLink.getNode("DispatcherID").getValueWithDefault<int>(200);
 
@@ -1342,6 +1344,7 @@ void ARTDAQTableBase::outputOnlineMonitorFHICL(const ConfigurationTree& monitorN
 			OUT << "max_fragment_size_words: " << max_fragment_size << "\n";
 			OUT << "source_rank: " << disp_fake_rank << "\n";
 			OUT << "destination_rank: " << om_rank << "\n";
+			OUT << "port: " << om_tcp_listen_port << "\n";
 			OUT << "unique_label: " << monitorNode.getValue() << "_to_"
 			    << dispatcherLink.getValue() << "\n";
 			POPTAB;

--- a/otsdaq/TablePlugins/ARTDAQTableBase/ARTDAQTableBase.cc
+++ b/otsdaq/TablePlugins/ARTDAQTableBase/ARTDAQTableBase.cc
@@ -1325,7 +1325,7 @@ void ARTDAQTableBase::outputOnlineMonitorFHICL(const ConfigurationTree& monitorN
 			OUT << "source.commanderPluginType: xmlrpc\n";
 
 			int om_rank = monitorNode.getNode("MonitorID").getValue<int>();
-            int om_tcp_listen_port =
+			int om_tcp_listen_port =
 			    monitorNode.getNode("MonitorTCPListenPort").getValue<int>();
 			int disp_fake_rank =
 			    dispatcherLink.getNode("DispatcherID").getValueWithDefault<int>(200);


### PR DESCRIPTION
differing partitions.