### PR TITLE
Added core count and RAM to Supervisor System Variable map

### DIFF
--- a/otsdaq/ConfigurationInterface/ConfigurationManager.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManager.cc
@@ -1750,7 +1750,7 @@ void ConfigurationManager::loadMemberMap(
 
 	//Note: mongodb crashing from too many connections was resolved by increasing ulimit at mongodb launch
 	//	 i.e. ulimit -n 64000 && ./start_mongod.sh
-	const int numOfThreads = StringMacros::getConcurrencyCount() / 2 > memberMap.size()
+	const int numOfThreads = StringMacros::getConcurrencyCount() / 2 < memberMap.size()
 	                             ? (StringMacros::getConcurrencyCount() / 2)
 	                             : memberMap.size();
 	if(memberMap.size() <= 2 /* i.e. is Context group */ || usingCache ||

--- a/otsdaq/ConfigurationInterface/ConfigurationManager.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManager.cc
@@ -1750,8 +1750,9 @@ void ConfigurationManager::loadMemberMap(
 
 	//Note: mongodb crashing from too many connections was resolved by increasing ulimit at mongodb launch
 	//	 i.e. ulimit -n 64000 && ./start_mongod.sh
-	const int numOfThreads =
-	    StringMacros::getConcurrencyCount() / 2 > memberMap.size() ? (StringMacros::getConcurrencyCount() / 2) : memberMap.size();
+	const int numOfThreads = StringMacros::getConcurrencyCount() / 2 > memberMap.size()
+	                             ? (StringMacros::getConcurrencyCount() / 2)
+	                             : memberMap.size();
 	if(memberMap.size() <= 2 /* i.e. is Context group */ || usingCache ||
 	   numOfThreads < 2)  // no multi-threading
 	{
@@ -1878,7 +1879,8 @@ void ConfigurationManager::loadMemberMap(
 	}
 	else  //multi-threading
 	{
-		__GEN_COUTT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> " << numOfThreads
+		__GEN_COUTT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount()
+		              << " ==> " << numOfThreads
 		              << " threads for loading member map of size " << memberMap.size()
 		              << __E__;
 
@@ -2486,7 +2488,8 @@ void ConfigurationManager::loadTableGroup(
 					progressBar->step();
 
 				const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
-				__GEN_COUTT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> "
+				__GEN_COUTT__ << " getConcurrencyCount "
+				              << StringMacros::getConcurrencyCount() << " ==> "
 				              << numOfThreads
 				              << " threads for initializing tables for Table Group '"
 				              << groupName << "(" << groupKey << ")'." << __E__;
@@ -2926,8 +2929,9 @@ void ConfigurationManager::copyTableGroupFromCache(
 		{
 			std::string accumulatedWarnings;
 			const int   numOfThreads = StringMacros::getConcurrencyCount() / 2;
-			__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> "
-			             << numOfThreads << " threads for initializing tables." << __E__;
+			__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount()
+			             << " ==> " << numOfThreads << " threads for initializing tables."
+			             << __E__;
 			if(groupType != ConfigurationManager::GroupType::CONFIGURATION_TYPE ||
 			   numOfThreads < 2)  // no multi-threading
 			{

--- a/otsdaq/ConfigurationInterface/ConfigurationManager.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManager.cc
@@ -18,9 +18,6 @@ using namespace ots;
 
 // clang-format off
 
-///may return 0 when not able to detect number of processors
-const unsigned int 		ConfigurationManager::PROCESSOR_COUNT 						= std::thread::hardware_concurrency();
-
 const std::string 		ConfigurationManager::LAST_TABLE_GROUP_SAVE_PATH 			= ((getenv("SERVICE_DATA_PATH") == NULL)
 																						? (std::string(__ENV__("USER_DATA")) + "/ServiceData")
 																						: (std::string(__ENV__("SERVICE_DATA_PATH")))) +
@@ -1754,7 +1751,7 @@ void ConfigurationManager::loadMemberMap(
 	//Note: mongodb crashing from too many connections was resolved by increasing ulimit at mongodb launch
 	//	 i.e. ulimit -n 64000 && ./start_mongod.sh
 	const int numOfThreads =
-	    PROCESSOR_COUNT / 2 > memberMap.size() ? (PROCESSOR_COUNT / 2) : memberMap.size();
+	    StringMacros::getConcurrencyCount() / 2 > memberMap.size() ? (StringMacros::getConcurrencyCount() / 2) : memberMap.size();
 	if(memberMap.size() <= 2 /* i.e. is Context group */ || usingCache ||
 	   numOfThreads < 2)  // no multi-threading
 	{
@@ -1881,7 +1878,7 @@ void ConfigurationManager::loadMemberMap(
 	}
 	else  //multi-threading
 	{
-		__GEN_COUTT__ << " PROCESSOR_COUNT " << PROCESSOR_COUNT << " ==> " << numOfThreads
+		__GEN_COUTT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> " << numOfThreads
 		              << " threads for loading member map of size " << memberMap.size()
 		              << __E__;
 
@@ -2488,8 +2485,8 @@ void ConfigurationManager::loadTableGroup(
 				if(progressBar)
 					progressBar->step();
 
-				const int numOfThreads = PROCESSOR_COUNT / 2;
-				__GEN_COUTT__ << " PROCESSOR_COUNT " << PROCESSOR_COUNT << " ==> "
+				const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
+				__GEN_COUTT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> "
 				              << numOfThreads
 				              << " threads for initializing tables for Table Group '"
 				              << groupName << "(" << groupKey << ")'." << __E__;
@@ -2928,8 +2925,8 @@ void ConfigurationManager::copyTableGroupFromCache(
 		if(doActivate)
 		{
 			std::string accumulatedWarnings;
-			const int   numOfThreads = PROCESSOR_COUNT / 2;
-			__GEN_COUT__ << " PROCESSOR_COUNT " << PROCESSOR_COUNT << " ==> "
+			const int   numOfThreads = StringMacros::getConcurrencyCount() / 2;
+			__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> "
 			             << numOfThreads << " threads for initializing tables." << __E__;
 			if(groupType != ConfigurationManager::GroupType::CONFIGURATION_TYPE ||
 			   numOfThreads < 2)  // no multi-threading

--- a/otsdaq/ConfigurationInterface/ConfigurationManager.h
+++ b/otsdaq/ConfigurationInterface/ConfigurationManager.h
@@ -34,8 +34,6 @@ class ConfigurationManager
 
 	//==============================================================================
 	/// Static members
-	static const unsigned int PROCESSOR_COUNT;
-
 	static const std::string READONLY_USER;
 	static const std::string ACTIVE_GROUPS_FILENAME;
 	static const std::string ALIAS_VERSION_PREAMBLE;

--- a/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
@@ -238,8 +238,8 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 		char                fileExt[]         = TABLE_INFO_EXT;
 		const unsigned char MIN_TABLE_NAME_SZ = 3;
 
-		const int numOfThreads = PROCESSOR_COUNT / 2;
-		__GEN_COUT__ << " PROCESSOR_COUNT " << PROCESSOR_COUNT << " ==> " << numOfThreads
+		const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
+		__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> " << numOfThreads
 		             << " threads." << __E__;
 		if(numOfThreads < 2)  // no multi-threading
 		{
@@ -568,8 +568,8 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 			// for each group get member map & comment, author, time, and type for latest key
 			if(getGroupInfo)
 			{
-				const int numOfThreads = PROCESSOR_COUNT / 2;
-				__GEN_COUT__ << " PROCESSOR_COUNT " << PROCESSOR_COUNT << " ==> "
+				const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
+				__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> "
 				             << numOfThreads << " threads." << __E__;
 				if(numOfThreads < 2)  // no multi-threading
 					for(auto& groupInfo : allGroupInfo_)
@@ -1491,7 +1491,7 @@ void ConfigurationManagerRW::preloadVersionCreationTimes(void)
 	             << " version creation times for " << groupedWork.size() << " tables..."
 	             << __E__;
 
-	int numOfThreads = PROCESSOR_COUNT / 2;
+	int numOfThreads = StringMacros::getConcurrencyCount() / 2;
 	if(numOfThreads > (int)flatWork.size())
 		numOfThreads = flatWork.size();
 
@@ -1899,8 +1899,8 @@ TableGroupKey ConfigurationManagerRW::findTableGroup(
 
 	// have min key to check, now loop through and check groups
 
-	const int numOfThreads = PROCESSOR_COUNT / 2;
-	__GEN_COUT__ << " PROCESSOR_COUNT " << PROCESSOR_COUNT << " ==> " << numOfThreads
+	const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
+	__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> " << numOfThreads
 	             << " threads." << __E__;
 	if(numOfThreads < 2)  // no multi-threading
 	{

--- a/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
+++ b/otsdaq/ConfigurationInterface/ConfigurationManagerRW.cc
@@ -239,8 +239,8 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 		const unsigned char MIN_TABLE_NAME_SZ = 3;
 
 		const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
-		__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> " << numOfThreads
-		             << " threads." << __E__;
+		__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount()
+		             << " ==> " << numOfThreads << " threads." << __E__;
 		if(numOfThreads < 2)  // no multi-threading
 		{
 			if((pDIR = opendir(path.c_str())) != 0)
@@ -569,7 +569,8 @@ const std::map<std::string, TableInfo>& ConfigurationManagerRW::getAllTableInfo(
 			if(getGroupInfo)
 			{
 				const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
-				__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> "
+				__GEN_COUT__ << " getConcurrencyCount "
+				             << StringMacros::getConcurrencyCount() << " ==> "
 				             << numOfThreads << " threads." << __E__;
 				if(numOfThreads < 2)  // no multi-threading
 					for(auto& groupInfo : allGroupInfo_)
@@ -1900,8 +1901,8 @@ TableGroupKey ConfigurationManagerRW::findTableGroup(
 	// have min key to check, now loop through and check groups
 
 	const int numOfThreads = StringMacros::getConcurrencyCount() / 2;
-	__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount() << " ==> " << numOfThreads
-	             << " threads." << __E__;
+	__GEN_COUT__ << " getConcurrencyCount " << StringMacros::getConcurrencyCount()
+	             << " ==> " << numOfThreads << " threads." << __E__;
 	if(numOfThreads < 2)  // no multi-threading
 	{
 		std::map<std::string /*name*/, TableVersion /*version*/> compareToMemberMap;

--- a/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
@@ -90,9 +90,7 @@ CorePropertySupervisorBase::CorePropertySupervisorBase(xdaq::Application* applic
 		StringMacros::systemVariables_["ActiveStateMachine"]["runAlias"] 	= StringMacros::TBD;
 
 		{
-			unsigned int logicalCores = std::thread::hardware_concurrency();
-			StringMacros::systemVariables_["System"]["logicalCores"] =
-				logicalCores > 0 ? std::to_string(logicalCores) : "unknown";
+			StringMacros::getConcurrencyCount(); //fills systemVariables_["System"]["logicalCores"]
 
 			unsigned int physicalCores = getPhysicalCoreCount();
 			StringMacros::systemVariables_["System"]["physicalCores"] =

--- a/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
@@ -7,7 +7,6 @@
 #include <cstdint>        // for uint64_t
 #include <fstream>        // for reading /proc/cpuinfo
 #include <set>            // for counting unique physical cores
-#include <thread>         // for std::thread::hardware_concurrency
 
 using namespace ots;
 

--- a/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
@@ -4,9 +4,9 @@
 
 #include <sys/statvfs.h>  // for disk space checking with statvfs
 #include <sys/sysinfo.h>  // for sysinfo() to get total memory
-#include <fstream>          // for reading /proc/cpuinfo
-#include <set>              // for counting unique physical cores
-#include <thread>           // for std::thread::hardware_concurrency
+#include <fstream>        // for reading /proc/cpuinfo
+#include <set>            // for counting unique physical cores
+#include <thread>         // for std::thread::hardware_concurrency
 
 using namespace ots;
 
@@ -16,44 +16,44 @@ const CorePropertySupervisorBase::SupervisorProperties
 
 namespace
 {
-	unsigned int getPhysicalCoreCount()
+unsigned int getPhysicalCoreCount()
+{
+	std::ifstream cpuinfo("/proc/cpuinfo");
+	if(!cpuinfo.is_open())
+		return 0;
+
+	std::set<std::pair<int, int>> uniqueCores;
+	int                           physicalId = -1;
+	int                           coreId     = -1;
+	std::string                   line;
+
+	while(std::getline(cpuinfo, line))
 	{
-		std::ifstream cpuinfo("/proc/cpuinfo");
-		if(!cpuinfo.is_open())
-			return 0;
-
-		std::set<std::pair<int, int>> uniqueCores;
-		int physicalId = -1;
-		int coreId     = -1;
-		std::string line;
-
-		while(std::getline(cpuinfo, line))
+		if(line.find("physical id") == 0)
 		{
-			if(line.find("physical id") == 0)
-			{
-				auto pos = line.find(':');
-				if(pos != std::string::npos)
-					physicalId = std::stoi(line.substr(pos + 1));
-			}
-			else if(line.find("core id") == 0)
-			{
-				auto pos = line.find(':');
-				if(pos != std::string::npos)
-					coreId = std::stoi(line.substr(pos + 1));
-			}
-			else if(line.empty() && physicalId >= 0 && coreId >= 0)
-			{
-				uniqueCores.insert({physicalId, coreId});
-				physicalId = -1;
-				coreId     = -1;
-			}
+			auto pos = line.find(':');
+			if(pos != std::string::npos)
+				physicalId = std::stoi(line.substr(pos + 1));
 		}
-		if(physicalId >= 0 && coreId >= 0)
+		else if(line.find("core id") == 0)
+		{
+			auto pos = line.find(':');
+			if(pos != std::string::npos)
+				coreId = std::stoi(line.substr(pos + 1));
+		}
+		else if(line.empty() && physicalId >= 0 && coreId >= 0)
+		{
 			uniqueCores.insert({physicalId, coreId});
-
-		return static_cast<unsigned int>(uniqueCores.size());
+			physicalId = -1;
+			coreId     = -1;
+		}
 	}
-} // anonymous namespace
+	if(physicalId >= 0 && coreId >= 0)
+		uniqueCores.insert({physicalId, coreId});
+
+	return static_cast<unsigned int>(uniqueCores.size());
+}
+}  // anonymous namespace
 
 // clang-format off
 //==============================================================================

--- a/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
@@ -5,55 +5,12 @@
 #include <sys/statvfs.h>  // for disk space checking with statvfs
 #include <sys/sysinfo.h>  // for sysinfo() to get total memory
 #include <cstdint>        // for uint64_t
-#include <fstream>        // for reading /proc/cpuinfo
-#include <set>            // for counting unique physical cores
 
 using namespace ots;
 
 const CorePropertySupervisorBase::SupervisorProperties
     CorePropertySupervisorBase::SUPERVISOR_PROPERTIES =
         CorePropertySupervisorBase::SupervisorProperties();
-
-namespace
-{
-unsigned int getPhysicalCoreCount()
-{
-	std::ifstream cpuinfo("/proc/cpuinfo");
-	if(!cpuinfo.is_open())
-		return 0;
-
-	std::set<std::pair<int, int>> uniqueCores;
-	int                           physicalId = -1;
-	int                           coreId     = -1;
-	std::string                   line;
-
-	while(std::getline(cpuinfo, line))
-	{
-		if(line.find("physical id") == 0)
-		{
-			auto pos = line.find(':');
-			if(pos != std::string::npos)
-				physicalId = std::stoi(line.substr(pos + 1));
-		}
-		else if(line.find("core id") == 0)
-		{
-			auto pos = line.find(':');
-			if(pos != std::string::npos)
-				coreId = std::stoi(line.substr(pos + 1));
-		}
-		else if(line.empty() && physicalId >= 0 && coreId >= 0)
-		{
-			uniqueCores.insert({physicalId, coreId});
-			physicalId = -1;
-			coreId     = -1;
-		}
-	}
-	if(physicalId >= 0 && coreId >= 0)
-		uniqueCores.insert({physicalId, coreId});
-
-	return static_cast<unsigned int>(uniqueCores.size());
-}
-}  // anonymous namespace
 
 // clang-format off
 //==============================================================================
@@ -90,10 +47,6 @@ CorePropertySupervisorBase::CorePropertySupervisorBase(xdaq::Application* applic
 
 		{
 			StringMacros::getConcurrencyCount(); //fills systemVariables_["System"]["logicalCores"]
-
-			unsigned int physicalCores = getPhysicalCoreCount();
-			StringMacros::systemVariables_["System"]["physicalCores"] =
-				physicalCores > 0 ? std::to_string(physicalCores) : "unknown";
 
 			struct sysinfo memInfo;
 			if(sysinfo(&memInfo) == 0)

--- a/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
@@ -3,12 +3,57 @@
 #include "otsdaq/MessageFacility/TRACEController.h"
 
 #include <sys/statvfs.h>  // for disk space checking with statvfs
+#include <sys/sysinfo.h>  // for sysinfo() to get total memory
+#include <fstream>          // for reading /proc/cpuinfo
+#include <set>              // for counting unique physical cores
+#include <thread>           // for std::thread::hardware_concurrency
 
 using namespace ots;
 
 const CorePropertySupervisorBase::SupervisorProperties
     CorePropertySupervisorBase::SUPERVISOR_PROPERTIES =
         CorePropertySupervisorBase::SupervisorProperties();
+
+namespace
+{
+	unsigned int getPhysicalCoreCount()
+	{
+		std::ifstream cpuinfo("/proc/cpuinfo");
+		if(!cpuinfo.is_open())
+			return 0;
+
+		std::set<std::pair<int, int>> uniqueCores;
+		int physicalId = -1;
+		int coreId     = -1;
+		std::string line;
+
+		while(std::getline(cpuinfo, line))
+		{
+			if(line.find("physical id") == 0)
+			{
+				auto pos = line.find(':');
+				if(pos != std::string::npos)
+					physicalId = std::stoi(line.substr(pos + 1));
+			}
+			else if(line.find("core id") == 0)
+			{
+				auto pos = line.find(':');
+				if(pos != std::string::npos)
+					coreId = std::stoi(line.substr(pos + 1));
+			}
+			else if(line.empty() && physicalId >= 0 && coreId >= 0)
+			{
+				uniqueCores.insert({physicalId, coreId});
+				physicalId = -1;
+				coreId     = -1;
+			}
+		}
+		if(physicalId >= 0 && coreId >= 0)
+			uniqueCores.insert({physicalId, coreId});
+
+		return static_cast<unsigned int>(uniqueCores.size());
+	}
+} // anonymous namespace
 
 // clang-format off
 //==============================================================================
@@ -42,6 +87,29 @@ CorePropertySupervisorBase::CorePropertySupervisorBase(xdaq::Application* applic
 		StringMacros::systemVariables_["ActiveStateMachine"]["name"] 		= StringMacros::TBD;
 		StringMacros::systemVariables_["ActiveStateMachine"]["windowName"] 	= StringMacros::TBD;
 		StringMacros::systemVariables_["ActiveStateMachine"]["runAlias"] 	= StringMacros::TBD;
+
+		{
+			unsigned int logicalCores = std::thread::hardware_concurrency();
+			StringMacros::systemVariables_["System"]["logicalCores"] =
+				logicalCores > 0 ? std::to_string(logicalCores) : "unknown";
+
+			unsigned int physicalCores = getPhysicalCoreCount();
+			StringMacros::systemVariables_["System"]["physicalCores"] =
+				physicalCores > 0 ? std::to_string(physicalCores) : "unknown";
+
+			struct sysinfo memInfo;
+			if(sysinfo(&memInfo) == 0)
+			{
+				uint64_t totalMemMB =
+					static_cast<uint64_t>(memInfo.totalram) * memInfo.mem_unit / (1024 * 1024);
+				StringMacros::systemVariables_["System"]["totalMemoryMB"] =
+					std::to_string(totalMemMB);
+			}
+			else
+			{
+				StringMacros::systemVariables_["System"]["totalMemoryMB"] = "unknown";
+			}
+		}
 	} // end init StringMacros::systemVariables_
 	__SUP_COUTV__(StringMacros::mapToString(StringMacros::systemVariables_));
 

--- a/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
+++ b/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc
@@ -4,6 +4,7 @@
 
 #include <sys/statvfs.h>  // for disk space checking with statvfs
 #include <sys/sysinfo.h>  // for sysinfo() to get total memory
+#include <cstdint>        // for uint64_t
 #include <fstream>        // for reading /proc/cpuinfo
 #include <set>            // for counting unique physical cores
 #include <thread>         // for std::thread::hardware_concurrency

--- a/otsdaq/Macros/StringMacros.cc
+++ b/otsdaq/Macros/StringMacros.cc
@@ -3,6 +3,7 @@
 #include <algorithm>  // for find_if
 #include <array>
 #include <cstdint>  // for uintptr_t
+#include <thread>   // for std::thread::hardware_concurrency
 
 using namespace ots;
 
@@ -10,6 +11,21 @@ std::map<std::string /* system variable */,
          std::map<std::string /* property */, std::string /* value */>>
                   StringMacros::systemVariables_;
 const std::string StringMacros::TBD = "To-be-defined";
+
+//==============================================================================
+unsigned int StringMacros::getConcurrencyCount(void)
+{
+	try
+	{
+		unsigned int val = std::stoul(systemVariables_.at("System").at("logicalCores"));
+		return val > 0 ? val : 4;
+	}
+	catch(...) {}
+	unsigned int hw = std::thread::hardware_concurrency();
+	unsigned int retVal = hw > 0 ? hw : 4;
+	systemVariables_["System"]["logicalCores"] = std::to_string(retVal);
+	return retVal;
+} //end getConcurrencyCount()
 
 #define TLVL_EscapeString 30  // = TLVL_DEBUG + 30
 #define TLVL_EnvMath 49       // = TLVL_DEBUG + 49

--- a/otsdaq/Macros/StringMacros.cc
+++ b/otsdaq/Macros/StringMacros.cc
@@ -20,12 +20,14 @@ unsigned int StringMacros::getConcurrencyCount(void)
 		unsigned int val = std::stoul(systemVariables_.at("System").at("logicalCores"));
 		return val > 0 ? val : 4;
 	}
-	catch(...) {}
-	unsigned int hw = std::thread::hardware_concurrency();
-	unsigned int retVal = hw > 0 ? hw : 4;
+	catch(...)
+	{
+	}
+	unsigned int hw                            = std::thread::hardware_concurrency();
+	unsigned int retVal                        = hw > 0 ? hw : 4;
 	systemVariables_["System"]["logicalCores"] = std::to_string(retVal);
 	return retVal;
-} //end getConcurrencyCount()
+}  //end getConcurrencyCount()
 
 #define TLVL_EscapeString 30  // = TLVL_DEBUG + 30
 #define TLVL_EnvMath 49       // = TLVL_DEBUG + 49

--- a/otsdaq/Macros/StringMacros.cc
+++ b/otsdaq/Macros/StringMacros.cc
@@ -17,16 +17,14 @@ unsigned int StringMacros::getConcurrencyCount(void)
 {
 	try
 	{
-		unsigned int val = std::stoul(systemVariables_.at("System").at("logicalCores"));
-		return val > 0 ? val : 4;
+		return std::stoul(systemVariables_.at("System").at("logicalCores"));
 	}
 	catch(...)
 	{
 	}
 	unsigned int hw                            = std::thread::hardware_concurrency();
-	unsigned int retVal                        = hw > 0 ? hw : 4;
-	systemVariables_["System"]["logicalCores"] = std::to_string(retVal);
-	return retVal;
+	systemVariables_["System"]["logicalCores"] = std::to_string(hw);
+	return hw;
 }  //end getConcurrencyCount()
 
 #define TLVL_EscapeString 30  // = TLVL_DEBUG + 30

--- a/otsdaq/Macros/StringMacros.cc
+++ b/otsdaq/Macros/StringMacros.cc
@@ -3,7 +3,7 @@
 #include <algorithm>  // for find_if
 #include <array>
 #include <cstdint>  // for uintptr_t
-#include <thread>   // for std::thread::hardware_concurrency
+#include <sched.h>  // for sched_getaffinity
 
 using namespace ots;
 
@@ -22,7 +22,10 @@ unsigned int StringMacros::getConcurrencyCount(void)
 	catch(...)
 	{
 	}
-	unsigned int hw                            = std::thread::hardware_concurrency();
+	cpu_set_t mask;
+	unsigned int hw = 0;
+	if(sched_getaffinity(0, sizeof(mask), &mask) == 0)
+		hw = CPU_COUNT(&mask);
 	systemVariables_["System"]["logicalCores"] = std::to_string(hw);
 	return hw;
 }  //end getConcurrencyCount()

--- a/otsdaq/Macros/StringMacros.cc
+++ b/otsdaq/Macros/StringMacros.cc
@@ -1,9 +1,9 @@
 #include "otsdaq/Macros/StringMacros.h"
 
+#include <sched.h>    // for sched_getaffinity
 #include <algorithm>  // for find_if
 #include <array>
 #include <cstdint>  // for uintptr_t
-#include <sched.h>  // for sched_getaffinity
 
 using namespace ots;
 
@@ -22,7 +22,7 @@ unsigned int StringMacros::getConcurrencyCount(void)
 	catch(...)
 	{
 	}
-	cpu_set_t mask;
+	cpu_set_t    mask;
 	unsigned int hw = 0;
 	if(sched_getaffinity(0, sizeof(mask), &mask) == 0)
 		hw = CPU_COUNT(&mask);

--- a/otsdaq/Macros/StringMacros.h
+++ b/otsdaq/Macros/StringMacros.h
@@ -90,6 +90,7 @@ struct StringMacros
 		std::map<std::string /* property */,
 		std::string /* value */>>  							systemVariables_;
 	static const std::string								TBD; //for to-be-defined system variables (so there is a value in wiz mode, before configuration, etc.)
+	static unsigned int				getConcurrencyCount		(void);
 
 	static bool        			isNumber					(const std::string& stringToCheck); ///< Note: before call consider use of stringToCheck = StringMacros::convertEnvironmentVariables(stringToCheck)
 	static std::string  		getNumberType				(const std::string& stringToCheck); ///< Note: before call consider use of stringToCheck = StringMacros::convertEnvironmentVariables(stringToCheck)


### PR DESCRIPTION
All changes are in [CorePropertySupervisorBase.cc](vscode-webview://0oppak729bb03tj9315vjds9dpnm6ead57ddou4605ndthi4794v/otsdaq/otsdaq/CoreSupervisors/CorePropertySupervisorBase.cc). Here's the summary:

What changed — Three new system variables added to StringMacros::systemVariables_["System"]:

${OTS.System.logicalCores} — hyperthreaded core count via std::thread::hardware_concurrency()
${OTS.System.physicalCores} — physical cores via parsing /proc/cpuinfo unique (physical id, core id) pairs
${OTS.System.totalMemoryMB} — total RAM in MB via sysinfo()
Who gets them:

CoreSupervisorBase subclasses and GatewaySupervisor — yes, both go through the CorePropertySupervisorBase constructor
WizardSupervisor — no, it doesn't inherit CorePropertySupervisorBase (by design)
Verification checklist:

Build otsdaq — the only modified file is CorePropertySupervisorBase.cc
At startup, the existing mapToString(systemVariables_) debug print (line after the init block) will show the new System.* entries with actual values
The gateway JSON dump and convertEnvironmentVariables() substitution both iterate generically, so no other files needed changes